### PR TITLE
fix: update JSON property name for Longitude

### DIFF
--- a/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
+++ b/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
 
         <PackageId>Community.Blazor.MapLibre</PackageId>
-        <Version>0.3.1</Version>
+        <Version>0.3.2</Version>
         <Authors>Yet-Another-Solution</Authors>
         <Description>C# Wrapper around a MapLibre GL JS library</Description>
         <LicenseUrl>https://opensource.org/license/unlicense</LicenseUrl>

--- a/Community.Blazor.MapLibre/Models/LngLat.cs
+++ b/Community.Blazor.MapLibre/Models/LngLat.cs
@@ -7,7 +7,7 @@ namespace Community.Blazor.MapLibre.Models;
 /// </summary>
 public class LngLat
 {
-    [JsonPropertyName("lon")]
+    [JsonPropertyName("lng")]
     public double Longitude { get; set; }
     [JsonPropertyName("lat")]
     public double Latitude { get; set; }


### PR DESCRIPTION
- Rename JSON property from "lon" to "lng" in LngLat class.

This update ensures consistency with standard naming conventions and improves interoperability with external libraries or APIs that expect "lng" as the property name for longitude.