### PR TITLE
feat: add JSON property names to bounding box properties

### DIFF
--- a/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
+++ b/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
 
         <PackageId>Community.Blazor.MapLibre</PackageId>
-        <Version>0.3.2</Version>
+        <Version>0.3.3</Version>
         <Authors>Yet-Another-Solution</Authors>
         <Description>C# Wrapper around a MapLibre GL JS library</Description>
         <LicenseUrl>https://opensource.org/license/unlicense</LicenseUrl>

--- a/Community.Blazor.MapLibre/Models/LngLatBounds.cs
+++ b/Community.Blazor.MapLibre/Models/LngLatBounds.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 
 namespace Community.Blazor.MapLibre.Models;
 
@@ -11,11 +12,13 @@ public class LngLatBounds
     /// <summary>
     /// The southwest corner of the bounding box.
     /// </summary>
+    [JsonPropertyName("_sw")]
     public required LngLat Southwest { get; set; }
 
     /// <summary>
     /// The northeast corner of the bounding box.
     /// </summary>
+    [JsonPropertyName("_ne")]
     public required LngLat Northeast { get; set; }
 
     /// <summary>


### PR DESCRIPTION
- Annotated Southwest and Northeast properties with JsonPropertyName
- Updated project version to 0.3.3

This change ensures consistent JSON serialization/deserialization by specifying explicit property names. The version bump reflects the addition of this feature.