### PR TITLE
Adds antimeridian cutting

### DIFF
--- a/Community.Blazor.MapLibre/MapOptions.cs
+++ b/Community.Blazor.MapLibre/MapOptions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Community.Blazor.MapLibre.Models;
 
 namespace Community.Blazor.MapLibre;
@@ -337,5 +338,26 @@ public class MapOptions
     /// keep the camera above ground when pitch \> 90 degrees.
     /// </summary>
     public bool? CenterClampedToGround { get; set; }
+    
+    /// <summary>
+    /// <para>
+    /// Determines whether the library should automatically handle geographic data that
+    /// crosses the antimeridian (180° E or 180° W).
+    /// </para>
+    ///
+    /// <para>
+    /// According to <see href="https://tools.ietf.org/html/rfc7946#section-3.1.9">
+    /// RFC 7946 Section 3.1.9</see>, such objects SHOULD be split into two or more
+    /// objects that do not cross the antimeridian, while preserving equivalence.
+    /// </para>
+    ///
+    /// <para>
+    /// When set to <c>true</c>, all GeoJSON features crossing the antimeridian will be
+    /// automatically split into two parts. The data will be processed using
+    /// <see href="https://gitlab.com/avandesa/geojson-antimeridian-cut">geojson-antimeridian-cut</see>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("cutAtAntimeridian")]
+    public bool? CutAtAntimeridian { get; set; }
 }
 

--- a/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/LICENSE
+++ b/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 Alexander van de Sandt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/cut.js
+++ b/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/cut.js
@@ -1,0 +1,49 @@
+import { splitLineString, splitMultiLineString } from './geometry/lines.js';
+import { splitPolygon, splitMultiPolygon } from './geometry/polygons.js';
+import { splitFeature, splitFeatureCollection, splitGeometryCollection } from './geometry/features.js';
+import './util.js';
+
+/**
+ * Recursively up a GeoJSON Object (or its children, if applicable)
+ * @param {Object} object The GeoJSON Object to split up
+ * @param {string} object.type
+ * @param {number[]} [object.coordinates]
+ * @param {Object[]} [object.features]
+ * @param {Object[]} [object.geometries]
+ *
+ * @returns {Object} The processed `object`
+ */
+const splitGeoJSON = (object) => {
+    if (!object.type) {
+        throw new Error('Object is not a valid GeoJSON Object, must have \'type\' property');
+    }
+
+    if (typeof object.type !== 'string') {
+        throw new Error(`Property 'type' of GeoJSON Object must be 'string', is ${object.type}`);
+    }
+
+    switch (object.type) {
+        case 'LineString':
+            return splitLineString(object);
+        case 'MultiLineString':
+            return splitMultiLineString(object);
+        case 'Polygon':
+            return splitPolygon(object);
+        case 'MultiPolygon':
+            return splitMultiPolygon(object);
+        case 'Feature':
+            return splitFeature(object);
+        case 'FeatureCollection':
+            return splitFeatureCollection(object);
+        case 'GeometryCollection':
+            return splitGeometryCollection(object);
+        case 'Point':
+        case 'MultiPoint':
+            // Do not change these types of GeoJSON Objects
+            return object;
+        default:
+            throw new Error(`Invalid 'type' of GeoJSON object: ${object.type}`);
+    }
+};
+
+export default splitGeoJSON;

--- a/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/geometry/features.js
+++ b/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/geometry/features.js
@@ -1,0 +1,62 @@
+import {splitLineString, splitMultiLineString} from './lines.js';
+import {splitPolygon, splitMultiPolygon} from './polygons.js';
+
+const splitGeometryObject = (geometryObject) => {
+    switch (geometryObject.type) {
+        case 'LineString':
+            return splitLineString(geometryObject);
+        case 'MultiLineString':
+            return splitMultiLineString(geometryObject);
+        case 'Polygon':
+            return splitPolygon(geometryObject);
+        case 'MultiPolygon':
+            return splitMultiPolygon(geometryObject);
+        case 'GeometryCollection':
+            // eslint-disable-next-line no-use-before-define
+            return splitGeometryCollection(geometryObject);
+        case 'Point':
+        case 'MultiPoint':
+            // Do not change these types of GeoJSON Objects
+            return geometryObject;
+        default:
+            throw new Error(`Must be some geometry object, is ${geometryObject.type}`);
+    }
+};
+
+export const splitFeature = (feature) => {
+    const {
+        geometry,
+        properties,
+        type: _type,
+        ...rest
+    } = feature;
+
+    const rtnGeometry = (geometry) ? splitGeometryObject(geometry) : null;
+
+    return {
+        type: 'Feature',
+        geometry: rtnGeometry,
+        properties,
+        ...rest,
+    };
+};
+
+export const splitFeatureCollection = (featureCollection) => {
+    const {features, type: _type, ...rest} = featureCollection;
+
+    return {
+        type: 'FeatureCollection',
+        features: features.map(splitFeature),
+        ...rest,
+    };
+};
+
+export const splitGeometryCollection = (geometryCollection) => {
+    const {geometries, type: _type, ...rest} = geometryCollection;
+
+    return {
+        type: 'GeometryCollection',
+        geometries: geometries.map(splitGeometryObject),
+        ...rest,
+    };
+};

--- a/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/geometry/lines.js
+++ b/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/geometry/lines.js
@@ -1,0 +1,98 @@
+import {crossingPoints, antimeridianIntersect} from '../util.js';
+
+/**
+ * A LineString GeoJSON Object
+ * @typedef {Object} LineString
+ * @property {string} type
+ * @property {number[][]} coordinates
+ */
+
+/**
+ * A MultiLineString GeoJSON Object
+ * @typedef {Object} MultiLineString
+ * @property {string} type
+ * @property {number[][][]} coordinates
+ */
+
+/**
+ * Splits up an array of coordinates into an array of arrays of coordinates. The fundamental
+ * function for breaking up (Multi)?LineStrings
+ *
+ * @param {number[][]} coordinates The list of coordinates to try to split
+ * @returns {number[][][]}
+ */
+export const splitCoordinateArray = (coordinates) => {
+    const crossings = crossingPoints(coordinates);
+    if (crossings.length === 0) {
+        return [coordinates];
+    }
+
+    const rtn = [];
+
+    // Split up into segments on each side of meridian
+    rtn.push(coordinates.slice(0, crossings[0] + 1));
+    for (let i = 1; i < crossings.length; i += 1) {
+        rtn.push(coordinates.slice(crossings[i - 1] + 1, crossings[i] + 1));
+    }
+    rtn.push(coordinates.slice(crossings[crossings.length - 1] + 1));
+
+    // Add in the points on the meridian itself
+    for (let i = 1; i < rtn.length; i += 1) {
+        const left = rtn[i - 1];
+        const lastLeft = left[left.length - 1];
+        const right = rtn[i];
+        const firstRight = right[0];
+
+        const intersect = antimeridianIntersect(lastLeft, firstRight);
+
+        left.push([180 * Math.sign(lastLeft[0]), intersect]);
+        right.unshift([180 * Math.sign(firstRight[0]), intersect]);
+    }
+
+    return rtn;
+};
+
+/**
+ * Examines the `coordinates` of `lineString` to see if it would cross the antimeridian, and if so,
+ * transforms it into an equivalent `MultiLineString` broken up over the antimeridian.
+ *
+ * @param {LineString} lineString A `LineString` GeoJSON object to break up
+ * @returns {LineString|MultiLineString}
+ */
+export const splitLineString = (lineString) => {
+    const {coordinates, type: _type, ...rest} = lineString;
+
+    const crossings = crossingPoints(coordinates);
+
+    if (crossings.length === 0) {
+        return {
+            type: 'LineString',
+            coordinates,
+            ...rest,
+        };
+    }
+
+    return {
+        type: 'MultiLineString',
+        coordinates: splitCoordinateArray(coordinates),
+        ...rest,
+    };
+};
+
+/**
+ * Examines the `coordinates` of `multiLineString` to see if any of its components would cross the
+ * antimeridian, and if so, transforms it into an equivalent `MultiLineString` broken up over the
+ * antimeridian.
+ *
+ * @param {MultiLineString} multiLineString A `MultiLineString` GeoJSON Object to break up
+ * @returns {MultiLineString}
+ */
+export const splitMultiLineString = (multiLineString) => {
+    const {coordinates, type: _type, ...rest} = multiLineString;
+
+    return {
+        type: 'MultiLineString',
+        coordinates: coordinates.map(splitCoordinateArray).flat(1),
+        ...rest,
+    };
+};

--- a/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/geometry/polygons.js
+++ b/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/geometry/polygons.js
@@ -1,0 +1,156 @@
+import {
+    crossingPoints,
+    antimeridianIntersect,
+} from '../util.js';
+
+/**
+ * A Polygon GeoJSON object
+ * @typedef {Object} Polygon
+ * @property {string} type
+ * @property {LinearRing[]} coordinates
+ */
+
+/**
+ * A MultiPolygon GeoJSON object
+ * @typedef {Object} MultiPolygon
+ * @property {string} type
+ * @property {LinearRing[][]} coordinates
+ */
+
+/**
+ * An array of four or more coordinates that defines the boundary of a surface or a hole in a
+ * surface. The first coordinate must be equivalent to the last.
+ * @typedef {number[][]} LinearRing
+ */
+
+/**
+ * @param {LinearRing} linearRing
+ * @param {LinearRing[]} collector
+ */
+const splitLinearRing = (linearRing, collector) => {
+    const crossings = crossingPoints(linearRing);
+    if (crossings.length === 0) {
+        collector.push([linearRing]);
+        return;
+    }
+
+    // Get two highest-latitude intersection points
+    const [startIntersect, endIntersect] = crossings
+        .map(i => [
+            antimeridianIntersect(linearRing[i], linearRing[i + 1]),
+            i,
+        ])
+        .sort(([latA], [latB]) => latB - latA);
+
+    // Traverse from first intersection and build 'left' polygon
+    const leftRing = [];
+    // Add the first point (the intersection point)
+    let currentIndex = startIntersect[1] + 1;
+    if (currentIndex === linearRing.length - 1) {
+        currentIndex = 0;
+    }
+    let firstAfterIntersect = linearRing[currentIndex];
+
+    leftRing.push([180 * Math.sign(firstAfterIntersect[0]), startIntersect[0]]);
+    leftRing.push(linearRing[currentIndex]);
+    while (currentIndex !== endIntersect[1]) {
+        currentIndex += 1;
+        if (currentIndex === linearRing.length - 1) { // End of ring, wrap around
+            currentIndex = 0;
+        }
+
+        leftRing.push(linearRing[currentIndex]);
+    }
+    leftRing.push([180 * Math.sign(firstAfterIntersect[0]), endIntersect[0]]);
+
+    // Traverse from second intersection and build 'right' polygon;
+    const rightRing = [];
+    currentIndex = endIntersect[1] + 1;
+    if (currentIndex === linearRing.length - 1) {
+        currentIndex = 0;
+    }
+    firstAfterIntersect = linearRing[currentIndex];
+
+    rightRing.push([180 * Math.sign(firstAfterIntersect[0]), endIntersect[0]]);
+    rightRing.push(linearRing[currentIndex]);
+    while (currentIndex !== startIntersect[1]) {
+        currentIndex += 1;
+        if (currentIndex === linearRing.length - 1) {
+            currentIndex = 0;
+        }
+
+        rightRing.push(linearRing[currentIndex]);
+    }
+    rightRing.push([180 * Math.sign(firstAfterIntersect[0]), startIntersect[0]]);
+
+    // Duplicate first value at end to create a ring
+    leftRing.push(leftRing[0]);
+    rightRing.push(rightRing[0]);
+
+    splitLinearRing(leftRing, collector);
+    splitLinearRing(rightRing, collector);
+};
+
+/**
+ * Splits a polygon's linear rings. The first ring in the list is treated as the outer loop. The
+ * remaining rings, if they exist, are treated as holes. If the main ring is split, all holes are
+ * added to all resulting polygons. If a hole is split, the resulting rings are also applied to all
+ * top-level polygons.
+ *
+ * @param {LinearRing[]} rings A list of rings to spli
+ * @returns {LinearRing[][]}
+ */
+const splitPolygonRingList = (rings) => {
+    const [mainRing, ...holes] = rings;
+
+    const rtn = [];
+
+    // Split the main ring & push results into rtn value
+    splitLinearRing(mainRing, rtn);
+
+    // Split each hole and apply the cut holes to each resulting ring
+    if (holes) {
+        const cutHoles = [];
+        holes.forEach(hole => splitLinearRing(hole, cutHoles));
+        rtn.forEach(ring => cutHoles.flat().forEach(hole => ring.push(hole)));
+    }
+
+    return rtn;
+};
+
+/**
+ * @param {Polygon} polygon
+ * @returns {(MultiPolygon|Polygon)}
+ */
+export const splitPolygon = (polygon) => {
+    const {coordinates: linearRings, type: _type, ...rest} = polygon;
+
+    const cutPolygon = splitPolygonRingList(linearRings);
+    return (cutPolygon.length > 1)
+        ? {
+            type: 'MultiPolygon',
+            coordinates: cutPolygon,
+            ...rest,
+        }
+        : {
+            type: 'Polygon',
+            coordinates: cutPolygon.flat(),
+            ...rest,
+        };
+};
+
+/**
+ * @param {MultiPolygon} multiPolygon
+ * @returns {MultiPolygon}
+ */
+export const splitMultiPolygon = (multiPolygon) => {
+    const {coordinates: polygons, type: _type, ...rest} = multiPolygon;
+
+    const rtn = polygons.map(polygon => splitPolygonRingList(polygon)).flat();
+
+    return {
+        type: 'MultiPolygon',
+        coordinates: rtn,
+        ...rest,
+    };
+};

--- a/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/util.js
+++ b/Community.Blazor.MapLibre/wwwroot/geojson-antimeridian-cut/util.js
@@ -1,0 +1,94 @@
+/**
+ * @example
+ * bringLonWithinBounds(1) === 1;
+ * bringLonWithinBounds(181) === 1;
+ * bringLonWithinBounds(-365) === -5;
+ *
+ * @param {number} lon The longitude to reduce
+ * @returns {number} A longitude equivalent to `lon` between [-180, 180]
+ */
+export const bringLonWithinBounds = (lon) => {
+    let rtn = lon;
+
+    while (rtn > 180) {
+        rtn -= 360;
+    }
+
+    while (rtn < -180) {
+        rtn += 360;
+    }
+
+    return rtn;
+};
+
+/**
+ * Checks if the line drawn between two points would cross the antimeridian.
+ * @param {number[]} a The first point to check
+ * @param {number[]} b The second point to check
+ *
+ * @returns {boolean} `true` if the points straddle the antimeridian, `false` otherwise
+ */
+export const straddlesAntimeridian = ([lonARaw], [lonBRaw]) => {
+    // If they are more than 360 degrees apart, they must cross the antimeridian.
+    // Only applies to points with coords > 180 or < -180
+    if (lonARaw - lonBRaw >= 360 || lonARaw - lonBRaw <= -360) {
+        return true;
+    }
+
+    const lonA = bringLonWithinBounds(lonARaw);
+    const lonB = bringLonWithinBounds(lonBRaw);
+
+    if (Math.sign(lonA) === Math.sign(lonB)) {
+        return false;
+    }
+
+    return ((lonA > 0)
+        ? (lonB < -(180 - lonA))
+        : (lonA < -(180 - lonB))
+    );
+};
+
+/**
+ * Finds the points at which a list of coordinates crosses the antimeridian
+ *
+ * @param {number[][]} points The points to check
+ *
+ * @returns {number[]} The indicies of the `points` that occur immediately before a crossing
+ */
+export const crossingPoints = (points) => {
+    const rtn = [];
+
+    for (let i = 1; i < points.length; i += 1) {
+        const a = points[i - 1];
+        const b = points[i];
+
+        if (straddlesAntimeridian(a, b)) {
+            rtn.push(i - 1);
+        }
+    }
+
+    return rtn;
+};
+
+const makeLonPositive = lon => ((lon < 0) ? makeLonPositive(lon + 360) : lon);
+
+/**
+ * Calculates the latitude at which a line drawn between two coordinates would intersect
+ * the antimeridian. Assumes that:
+ * * The line would cross the antimeridian
+ * * -180 < lon{A,B} < 180
+ * * -90 < lat{A,B} < 90
+ *
+ * @param {number[]} a The first point to check, [lon, lat]
+ * @param {number[]} b The second point to check, [lon, lat]
+ *
+ * @returns {number} The Antimeridian Intersect of `a` and `b`
+ */
+export const antimeridianIntersect = ([lonA, latA], [lonB, latB]) => {
+    const lonANorm = makeLonPositive(lonA);
+    const lonBNorm = makeLonPositive(lonB);
+
+    const slope = (latB - latA) / (lonBNorm - lonANorm);
+
+    return slope * (180 - lonANorm) + latA;
+};


### PR DESCRIPTION
This may be a debatable PR.  
GeoJSON is defined by the standard [RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946).  
Section [3.1.9](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.9) defines how to handle data that crosses the [antimeridian](https://en.wikipedia.org/wiki/180th_meridian).  
Such datasets need to be split into multiple datasets to ensure that no element crosses the line.  

This can be a cumbersome task, especially when working with third-party libraries that draw over the antimeridian.  
To address this, the NPM package [geojson-antimeridian-cut](https://www.npmjs.com/package/geojson-antimeridian-cut) has been created.  
This package is licensed under MIT, which grants the right to further distribute the software.  

---

With all this in mind, this PR integrates this functionality into the MapLibre library and introduces a new option on the map to automatically cut data crossing the antimeridian.  
All the code in `wwwroot/geojson-antimeridian-cut/` is a slightly modified version of `geojson-antimeridian-cut`, adapted to work with Blazor and native JavaScript.  

### Why include this code in this library?  
The data in my application does not handle antimeridian crossings correctly.  
One could argue that I should convert this library to C# and process the data before sending it to the map.  
While that is an option, I believe other users are likely to face the same issue.  

Therefore, I propose adding this feature as an opt-in option, allowing users to simply provide their existing GeoJSON data without needing additional preprocessing.