### PR TITLE
Adds a default map style

### DIFF
--- a/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
+++ b/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
@@ -15,6 +15,10 @@
         <PackageIconUrl>https://maplibre.org/img/maplibre-logos/maplibre-logo-square-dark-blue-bg.png</PackageIconUrl>
         <RootNamespace>Community.Blazor.MapLibre</RootNamespace>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        
+        <!-- Generate XML documentation file -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>1591</NoWarn> <!-- Suppresses missing XML comment warnings -->
     </PropertyGroup>
 
     <ItemGroup>

--- a/Community.Blazor.MapLibre/MapOptions.cs
+++ b/Community.Blazor.MapLibre/MapOptions.cs
@@ -416,11 +416,12 @@ public class MapOptions
 
     /// <summary>
     /// The MapLibre style, either as a JSON URL or a full style object.
-    /// When not specified, Map#setStyle must be called before rendering.
+    /// When not specified, it will use the same style as on the demo maps.
+    /// This can be overwritten with <see cref="MapLibre.SetStyle"/> before rendering.
     /// </summary>
     [JsonPropertyName("style")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public object? Style { get; set; }
+    public object? Style { get; set; } = "https://demotiles.maplibre.org/style.json";
 
     /// <summary>
     /// Enables \"drag to pitch\" interaction, or provides options for pitch behavior.


### PR DESCRIPTION
This pull request introduces improvements to the `Community.Blazor.MapLibre` library by enhancing documentation generation and updating default behavior for map styling. Below are the key changes:

### Documentation Enhancements:
* [`Community.Blazor.MapLibre.csproj`](diffhunk://#diff-dd3c7f88bb1b0e30554fe39a7678a163e146cb9cabc69b447b60c2f973a19467R18-R21): Enabled XML documentation file generation by adding `<GenerateDocumentationFile>true</GenerateDocumentationFile>` and suppressed missing XML comment warnings with `<NoWarn>1591</NoWarn>`.

### Default Map Styling:
* [`MapOptions.cs`](diffhunk://#diff-629b1373d5d6ecbe882903944fae0e26e15e4000a7a494af63bf7b0039487ec4L419-R424): Updated the default value of the `Style` property to use the demo map style (`"https://demotiles.maplibre.org/style.json"`) and clarified the behavior in the property summary. This ensures a default style is applied if none is specified.