### PR TITLE
Fix typo in `EaseToOptions` `JsonPropertyName` annotation. Closes #85

### DIFF
--- a/Community.Blazor.MapLibre/Models/Camera/EaseToOptions.cs
+++ b/Community.Blazor.MapLibre/Models/Camera/EaseToOptions.cs
@@ -10,7 +10,7 @@ public class EaseToOptions : IAnimationOptions, ICameraOptions
     /// <summary>
     /// If `zoom` is specified, `around` determines the point around which the zoom is centered.
     /// </summary>
-    [JsonPropertyName("animate")]
+    [JsonPropertyName("around")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public LngLat? Around { get; set; }
     


### PR DESCRIPTION
Addresses bug https://github.com/Yet-another-solution/Blazor.MapLibre/issues/85