### PR TITLE
Pass `MapId` to `executeTransaction` JavaScript interop. Closes #87

### DIFF
--- a/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -1267,7 +1267,7 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
             throw new InvalidOperationException("No bulk transaction is in progress.");
         }
 
-        await _jsModule.InvokeVoidAsync("executeTransaction", _bulkTransaction.Transactions);
+        await _jsModule.InvokeVoidAsync("executeTransaction", MapId, _bulkTransaction.Transactions);
         _bulkTransaction = null;
     }
 


### PR DESCRIPTION
Addresses bug https://github.com/Yet-another-solution/Blazor.MapLibre/issues/87