### PR TITLE
Adds base docfx docs site with dotnet CLI support

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/Community.Blazor.MapLibre.slnx
+++ b/Community.Blazor.MapLibre.slnx
@@ -1,4 +1,7 @@
 ﻿<Solution>
+  <Folder Name="/docs/">
+    <Project Path="docs\Community.Blazor.Documentation.csproj" Type="Classic C#" />
+  </Folder>
   <Folder Name="/examples/">
     <Project Path="examples\Community.Blazor.MapLibre.Examples\Community.Blazor.MapLibre.Examples.csproj" Type="Classic C#" />
   </Folder>

--- a/docs/.config/dotnet-tools.json
+++ b/docs/.config/dotnet-tools.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.3",
+      "commands": [
+        "docfx"
+      ],
+      "rollForward": false
+    },
+    "docfxtocgenerator": {
+      "version": "1.33.0",
+      "commands": [
+        "DocFxTocGenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,7 @@
+# Ignore build output and intermediate folders
+bin/
+obj/
+dist/
+
+# Ignore toc.yml files that are 2 or more folders deep
+**/**/**/toc.yml

--- a/docs/Community.Blazor.Documentation.csproj
+++ b/docs/Community.Blazor.Documentation.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Community.Blazor.MapLibre</RootNamespace>
+    </PropertyGroup>
+
+    <Target Name="ClearBuildArtifacts" AfterTargets="Clean">
+        <RemoveDir Directories="dist"/>
+        <RemoveDir Directories="api"/>
+        <RemoveDir Directories="obj"/>
+        <RemoveDir Directories="bin"/>
+    </Target>
+
+    <Target Name="IntallTools" AfterTargets="AfterBuild">
+        <Exec Command="dotnet tool restore"/>
+    </Target>
+
+    <Target Name="BuildTableOfContents" AfterTargets="AfterBuild">
+        <Exec Command="dotnet DocFxTocGenerator --docfolder ./content/getting-started --outfolder ./content/getting-started --sequence --override"/>
+        <Exec Command="dotnet DocFxTocGenerator --docfolder ./content/api --outfolder ./content/api --sequence --override"/>
+    </Target>
+
+    <Target Name="BuildSite" AfterTargets="AfterBuild">
+        <Exec Command="dotnet docfx docfx.json"/>
+    </Target>
+
+</Project>

--- a/docs/Program.cs
+++ b/docs/Program.cs
@@ -1,7 +1,13 @@
+using System;
 using System.Diagnostics;
+using System.IO;
+
+var projectDirectory = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
 
 Process.Start(new ProcessStartInfo {
     FileName = "dotnet",
-    Arguments = "docfx serve dist --open-browser",
-    UseShellExecute = false
+    Arguments = "docfx docfx.json --serve --open-browser",
+    UseShellExecute = false,
+    WorkingDirectory = projectDirectory
 })!.WaitForExit();
+

--- a/docs/Program.cs
+++ b/docs/Program.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics;
+
+Process.Start(new ProcessStartInfo {
+    FileName = "dotnet",
+    Arguments = "docfx serve dist --open-browser",
+    UseShellExecute = false
+})!.WaitForExit();

--- a/docs/content/.order
+++ b/docs/content/.order
@@ -1,0 +1,1 @@
+getting-started

--- a/docs/content/api/handlers/index.md
+++ b/docs/content/api/handlers/index.md
@@ -1,0 +1,3 @@
+# Handlers
+
+Placeholder

--- a/docs/content/api/index.md
+++ b/docs/content/api/index.md
@@ -1,0 +1,3 @@
+# API
+
+Placeholder

--- a/docs/content/api/map/index.md
+++ b/docs/content/api/map/index.md
@@ -1,0 +1,3 @@
+# Map
+
+Placeholder

--- a/docs/content/getting-started/.order
+++ b/docs/content/getting-started/.order
@@ -1,0 +1,3 @@
+introduction
+key-concepts
+contributing

--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Placeholder
+
+## Documentation
+
+You can build and run the documentation site using the .NET CLI command below from the `/docs` folder.
+
+| Command        | Description                                      |
+|----------------|--------------------------------------------------|
+| `dotnet clean` | Clean the docs and .NET build artifacts.         |
+| `dotnet build` | Build the docs site to the `/docs/dist` folder.  |
+| `dotnet run`   | Build and preview the docs site in your browser. |

--- a/docs/content/getting-started/introduction.md
+++ b/docs/content/getting-started/introduction.md
@@ -1,0 +1,3 @@
+# Introduction
+
+Placeholder

--- a/docs/content/getting-started/key-concepts.md
+++ b/docs/content/getting-started/key-concepts.md
@@ -1,0 +1,3 @@
+# Key concepts
+
+Placeholder

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "exclude": [
+          "dist/**"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "images/**"
+        ]
+      }
+    ],
+    "output": "dist",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appTitle": "Blazor MapLibre",
+      "_enableSearch": true,
+      "pdf": false
+    }
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Blazor MapLibre
+
+Placeholder


### PR DESCRIPTION
Adds a basic [docfx](https://dotnet.github.io/docfx/) static documentation site as per https://github.com/Yet-another-solution/Blazor.MapLibre/issues/99.

#### This pull request includes ✅

- Support building/running using .NET CLI via `dotnet build` and `dotnet run`
- Uses MS Build and `.csproj` project file for build orchestration
- Adds documentation project to the Visual Studio solution
- Restoration of `dotnet tool`'s handled by `.csproj` build
- Adds basic folder structure to demonstrate folder hierarchy support
- Table of content generation is automated below `/content` levels using [docfxtocgenerator](https://github.com/Ellerbach/docfx-companion-tools)
- Full site search
- Table of contents search

![chrome_U5szrIOej2](https://github.com/user-attachments/assets/b9f87b7b-ae39-45a4-97f0-304b329eafb1)

#### What this pull request does not cover ❌

- Addition of or migration of documentation into doc directory (other than instructions on running the docs)
- Updates to GitHub Actions workflows to build and publish the site (future concern?)
- Styling and heavy customizations

#### Future improvements 🤔

- Supporting `dotnet watch` for live reloading of the docs site when making local edits
- Integration with GitHub Action workflows to build and publish to GitHub Pages
- Integration of examples in the docs site using [Blazor custom elements](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/js-spa-frameworks?view=aspnetcore-9.0#blazor-custom-elements)
- Automatic generation of Blazor MapLibre [.NET API documentation](https://dotnet.github.io/docfx/docs/dotnet-api-docs.html) in docfx