### PR TITLE
Adds Map.setMaxBounds

### DIFF
--- a/src/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -400,6 +400,15 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
         await _jsModule.InvokeVoidAsync("fitBounds", MapId, bounds, options, eventData);
 
     /// <summary>
+    /// Sets or clears the map's geographical bounds.
+    /// </summary>
+    /// <param name="bounds">The maximum bounds to set. If null or undefined is provided, the function removes the map's maximum bounds.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <see href="https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#setmaxbounds">setMaxBounds</see>
+    public async ValueTask SetMaxBounds(LngLatBounds bounds) =>
+        await _jsModule.InvokeVoidAsync("setMaxBounds", MapId, bounds);
+
+    /// <summary>
     /// Pans, rotates, and zooms the map to fit the bounding box formed by two given screen points
     /// after rotating the map to the specified bearing. If the current map bearing is passed, the map will
     /// zoom without rotating.

--- a/src/Community.Blazor.MapLibre/MapLibre.razor.js
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor.js
@@ -297,6 +297,19 @@ export function fitBounds(container, bounds, options, eventData) {
 }
 
 /**
+ * Sets or clears the map's geographical bounds.
+ *
+ * @param {string} container - The identifier for the map container that needs to fit the bounds.
+ * @param {Object} bounds - The maximum bounds to set. If null or undefined is provided, the function removes the map's maximum bounds.
+ */
+export function setMaxBounds(container, bounds) {
+    mapInstances[container].setMaxBounds([
+        [bounds._sw.lng, bounds._sw.lat], // Southwest corner
+        [bounds._ne.lng, bounds._ne.lat]  // Northeast corner
+    ]);
+}
+
+/**
  * Adjusts the map view to fit the given screen coordinates.
  *
  * @function fitScreenCoordinates


### PR DESCRIPTION
#### MapLibre documentation

https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#setmaxbounds

#### Example usage

```csharp
await _map.SetMaxBounds(
    LngLatBounds.FromLngLat(
        new LngLat(-7.957225, 53.4494762),1000*350
    )
);
```