### PR TITLE
feat: remove inline CSS inclusion and bump version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Install the package:
 dotnet add package Community.Blazor.MapLibre
 ```
 
-For Blazor Server and Blazor Web App, add this to head of your file to load the css of the maps.
+Add this to head of your file to load the css for the maps.
 ```html
 <link href="_content/Community.Blazor.MapLibre/maplibre-5.3.0.min.css" rel="stylesheet" />
 ```

--- a/src/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
+++ b/src/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
 
         <PackageId>Community.Blazor.MapLibre</PackageId>
-        <Version>1.0.6</Version>
+        <Version>1.1.0</Version>
         <Authors>Yet-Another-Solution</Authors>
         <Description>C# Wrapper around a MapLibre GL JS library</Description>
         <LicenseUrl>https://opensource.org/license/unlicense</LicenseUrl>

--- a/src/Community.Blazor.MapLibre/MapLibre.razor
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor
@@ -1,7 +1,3 @@
-<HeadContent>
-    <link href="_content/Community.Blazor.MapLibre/maplibre-5.3.0.min.css" rel="stylesheet" />
-</HeadContent>
-
 <div id="@MapId"
      style="width: @Width; height: @Height"
      class="@Class">


### PR DESCRIPTION
- Removed the `<HeadContent>` section with CSS in `MapLibre.razor`
- Updated documentation to include CSS link instructions
- Increased package version from 1.0.6 to 1.1.0

CSS inclusion is now handled via external configuration, simplifying the component. Version bump reflects this enhancement and ensures consumers adopt the updated approach.