### PR TITLE
feat: extend ISource with additional properties

### DIFF
--- a/src/Community.Blazor.MapLibre/Models/Sources/GeoJsonSource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/GeoJsonSource.cs
@@ -13,6 +13,37 @@ public class GeoJsonSource : ISource
     [JsonPropertyName("type")]
     public string Type => "geojson";
 
+    /// <inheritdoc />
+    [JsonPropertyName("attribution")]
+    public string? Attribution { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("isTileClipped")]
+    public bool? IsTileClipped { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("maxzoom")]
+    public float? MaxZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("minzoom")]
+    public float? MinZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("reparseOverscaled")]
+    public bool? ReparseOverscaled { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("roundZoom")]
+    public bool? RoundZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileID")]
+    public string? TileID { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileSize")]
+    public float? TileSize { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("vectorLayerIds")]
+    public string[]? VectorLayerIds { get; set; }
+
     /// <summary>
     /// The GeoJSON data, either as an inline object or a URL to an external GeoJSON file. Required.
     /// </summary>

--- a/src/Community.Blazor.MapLibre/Models/Sources/ISource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/ISource.cs
@@ -17,5 +17,65 @@ public interface ISource
     /// Defines the source type (e.g., vector, raster, geojson, etc.).
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; }
+    string Type { get; }
+
+    /// <summary>
+    /// The attribution for the source.
+    /// </summary>
+    [JsonPropertyName("attribution")]
+    string? Attribution { get; set; }
+
+    /// <summary>
+    /// The id for the source. Must not be used by any existing source.
+    /// </summary>
+    [JsonPropertyName("id")]
+    string Id { get; set; }
+
+    /// <summary>
+    /// `false` if tiles can be drawn outside their boundaries, `true` if they cannot.
+    /// </summary>
+    [JsonPropertyName("isTileClipped")]
+    bool? IsTileClipped { get; set; }
+
+    /// <summary>
+    /// The maximum zoom level for the source.
+    /// </summary>
+    [JsonPropertyName("maxzoom")]
+    int MaxZoom { get; set; }
+
+    /// <summary>
+    /// The minimum zoom level for the source.
+    /// </summary>
+    [JsonPropertyName("minzoom")]
+    int MinZoom { get; set; }
+
+    /// <summary>
+    /// `true` if tiles should be sent back to the worker for each overzoomed zoom level, `false` if not.
+    /// </summary>
+    [JsonPropertyName("reparseOverscaled")]
+    bool? ReparseOverscaled { get; set; }
+
+    /// <summary>
+    /// `true` if zoom levels are rounded to the nearest integer in the source data, `false` if they are floor-ed to the nearest integer.
+    /// </summary>
+    [JsonPropertyName("roundZoom")]
+    bool? RoundZoom { get; set; }
+
+    /// <summary>
+    /// The canonical tile ID for the source.
+    /// </summary>
+    [JsonPropertyName("tileID")]
+    string? TileID { get; set; }
+
+    /// <summary>
+    /// The tile size for the source.
+    /// </summary>
+    [JsonPropertyName("tileSize")]
+    int TileSize { get; set; }
+
+    /// <summary>
+    /// The vector layer IDs for the source.
+    /// </summary>
+    [JsonPropertyName("vectorLayerIds")]
+    string[]? VectorLayerIds { get; set; }
 }

--- a/src/Community.Blazor.MapLibre/Models/Sources/ISource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/ISource.cs
@@ -29,7 +29,7 @@ public interface ISource
     /// The id for the source. Must not be used by any existing source.
     /// </summary>
     [JsonPropertyName("id")]
-    string Id { get; set; }
+    string? Id { get; set; }
 
     /// <summary>
     /// `false` if tiles can be drawn outside their boundaries, `true` if they cannot.
@@ -41,13 +41,13 @@ public interface ISource
     /// The maximum zoom level for the source.
     /// </summary>
     [JsonPropertyName("maxzoom")]
-    int MaxZoom { get; set; }
+    float? MaxZoom { get; set; }
 
     /// <summary>
     /// The minimum zoom level for the source.
     /// </summary>
     [JsonPropertyName("minzoom")]
-    int MinZoom { get; set; }
+    float? MinZoom { get; set; }
 
     /// <summary>
     /// `true` if tiles should be sent back to the worker for each overzoomed zoom level, `false` if not.
@@ -71,7 +71,7 @@ public interface ISource
     /// The tile size for the source.
     /// </summary>
     [JsonPropertyName("tileSize")]
-    int TileSize { get; set; }
+    float? TileSize { get; set; }
 
     /// <summary>
     /// The vector layer IDs for the source.

--- a/src/Community.Blazor.MapLibre/Models/Sources/ImageSource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/ImageSource.cs
@@ -10,6 +10,36 @@ public class ImageSource : ISource
     /// <inheritdoc />
     [JsonPropertyName("type")]
     public string Type => "image";
+    /// <inheritdoc />
+    [JsonPropertyName("attribution")]
+    public string? Attribution { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("isTileClipped")]
+    public bool? IsTileClipped { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("maxzoom")]
+    public float? MaxZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("minzoom")]
+    public float? MinZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("reparseOverscaled")]
+    public bool? ReparseOverscaled { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("roundZoom")]
+    public bool? RoundZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileID")]
+    public string? TileID { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileSize")]
+    public float? TileSize { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("vectorLayerIds")]
+    public string[]? VectorLayerIds { get; set; }
 
     /// <summary>
     /// The URL to the image. This is used to load the image to be displayed on the map. Required.

--- a/src/Community.Blazor.MapLibre/Models/Sources/RasterTileSource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/RasterTileSource.cs
@@ -10,6 +10,36 @@ public class RasterTileSource : ISource
     /// <inheritdoc />
     [JsonPropertyName("type")]
     public string Type => "raster";
+    /// <inheritdoc />
+    [JsonPropertyName("attribution")]
+    public string? Attribution { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("isTileClipped")]
+    public bool? IsTileClipped { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("maxzoom")]
+    public float? MaxZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("minzoom")]
+    public float? MinZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("reparseOverscaled")]
+    public bool? ReparseOverscaled { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("roundZoom")]
+    public bool? RoundZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileID")]
+    public string? TileID { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileSize")]
+    public float? TileSize { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("vectorLayerIds")]
+    public string[]? VectorLayerIds { get; set; }
 
     /// <summary>
     /// URL to a TileJSON resource providing metadata about this source. Optional.

--- a/src/Community.Blazor.MapLibre/Models/Sources/VectorTileSource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/VectorTileSource.cs
@@ -10,6 +10,36 @@ public class VectorTileSource : ISource
     /// <inheritdoc />
     [JsonPropertyName("type")]
     public string Type => "vector";
+    /// <inheritdoc />
+    [JsonPropertyName("attribution")]
+    public string? Attribution { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("isTileClipped")]
+    public bool? IsTileClipped { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("maxzoom")]
+    public float? MaxZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("minzoom")]
+    public float? MinZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("reparseOverscaled")]
+    public bool? ReparseOverscaled { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("roundZoom")]
+    public bool? RoundZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileID")]
+    public string? TileID { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileSize")]
+    public float? TileSize { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("vectorLayerIds")]
+    public string[]? VectorLayerIds { get; set; }
 
     /// <summary>
     /// URL to a TileJSON resource providing metadata about this source. Optional.
@@ -34,18 +64,4 @@ public class VectorTileSource : ISource
     /// </summary>
     [JsonPropertyName("scheme")]
     public string? Scheme { get; set; } = "xyz";
-
-    /// <summary>
-    /// Minimum zoom level for which tiles are available, as in the TileJSON spec.
-    /// Default is 0. Optional.
-    /// </summary>
-    [JsonPropertyName("minzoom")]
-    public float? MinZoom { get; set; }
-
-    /// <summary>
-    /// Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles at the maxzoom are used when displaying the map at higher zoom levels.
-    /// Default is 22. Optional.
-    /// </summary>
-    [JsonPropertyName("maxzoom")]
-    public float? MaxZoom { get; set; }
 }

--- a/src/Community.Blazor.MapLibre/Models/Sources/VideoSource.cs
+++ b/src/Community.Blazor.MapLibre/Models/Sources/VideoSource.cs
@@ -10,6 +10,36 @@ public class VideoSource : ISource
     /// <inheritdoc />
     [JsonPropertyName("type")]
     public string Type => "video";
+    /// <inheritdoc />
+    [JsonPropertyName("attribution")]
+    public string? Attribution { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("isTileClipped")]
+    public bool? IsTileClipped { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("maxzoom")]
+    public float? MaxZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("minzoom")]
+    public float? MinZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("reparseOverscaled")]
+    public bool? ReparseOverscaled { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("roundZoom")]
+    public bool? RoundZoom { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileID")]
+    public string? TileID { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("tileSize")]
+    public float? TileSize { get; set; }
+    /// <inheritdoc />
+    [JsonPropertyName("vectorLayerIds")]
+    public string[]? VectorLayerIds { get; set; }
 
     /// <summary>
     /// URLs to the video content. Multiple URLs should be provided for format compatibility across browsers. Required.


### PR DESCRIPTION
- Add properties for attribution, id, zoom levels, tile clipping, and vector layer IDs.
- Support enhanced configuration of map sources.

This update introduces several new properties to the `ISource` interface, providing greater flexibility and control over map data sources. These changes enhance functionality, including the support for zoom level settings, tile behaviors, and vector layer identification.

- closes: https://github.com/Yet-another-solution/Blazor.MapLibre/issues/54