### PR TITLE
Properly remove map resources on map component disposal

### DIFF
--- a/Community.Blazor.MapLibre.slnx
+++ b/Community.Blazor.MapLibre.slnx
@@ -3,6 +3,7 @@
     <Project Path="docs\Community.Blazor.Documentation.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/examples/">
+    <Project Path="examples\Community.Blazor.MapLibre.Examples.MapboxGlPlugin\Community.Blazor.MapLibre.Examples.MapboxGlPlugin.csproj" Type="Classic C#" />
     <Project Path="examples\Community.Blazor.MapLibre.Examples\Community.Blazor.MapLibre.Examples.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/items/">

--- a/examples/Community.Blazor.MapLibre.Examples/Pages/Example.razor
+++ b/examples/Community.Blazor.MapLibre.Examples/Pages/Example.razor
@@ -28,7 +28,8 @@
         new() { Title = "Create Popup", Url = "Examples/CreatePopup", ImageUrl = "img/examples/popup.png" },
         new() { Title = "Render Globe", Url = "Examples/RenderGlobe", ImageUrl = "img/examples/globe.png" },
         new() { Title = "Mapbox Draw GLJS", Url = "Examples/MapboxGlDraw", ImageUrl = "img/examples/drawgljs.png" },
-        new() { Title = "Create marker", Url = "Examples/marker", ImageUrl = "img/examples/marker.png" }
+        new() { Title = "Create marker", Url = "Examples/marker", ImageUrl = "img/examples/marker.png" },
+        new() { Title = "Multiple maps", Url = "Examples/multiple-maps", ImageUrl = "img/examples/basic.png" },
     ];
 
     // ExampleItem class to store information

--- a/examples/Community.Blazor.MapLibre.Examples/Pages/Examples/MultipleMaps.razor
+++ b/examples/Community.Blazor.MapLibre.Examples/Pages/Examples/MultipleMaps.razor
@@ -1,0 +1,80 @@
+﻿@page "/Examples/multiple-maps"
+@implements IAsyncDisposable
+
+<h3>Multiple maps</h3>
+
+<div class="alert alert-info" role="alert">
+    <h5 class="alert-heading">⚠️ WebGL Context Limitations</h5>
+    <p class="mb-2">
+        Multiple map components can be added to a page, but browsers have specific limitations on how many WebGL contexts can co-exist simultaneously.
+    </p>
+    <p class="mb-2">
+        <strong>Example:</strong> Chrome has a limit of 16 WebGL contexts. Any maps added beyond this limit will result in the oldest map losing its WebGL context and ceasing to work.
+    </p>
+    <p class="mb-0">
+        <strong>Note:</strong> Map components will properly dispose of their reserved WebGL context when they are destroyed, freeing up resources for new maps.
+    </p>
+</div>
+
+<div class="mb-3">
+    <label for="mapCountInput" class="form-label">Number of map components on the page</label>
+    <div class="input-group" style="max-width: 200px;">
+        <button class="btn btn-outline-secondary" @onclick="DecreaseMapCount">-</button>
+        <input id="mapCountInput" type="number" class="form-control" min="0" value="@_mapCount"
+               @oninput="OnMapCountChange" style="max-width: 75px;"/>
+        <button class="btn btn-outline-secondary" @onclick="IncreaseMapCount">+</button>
+    </div>
+</div>
+
+<div class="map-grid">
+    @for (var i = 0; i < _mapCount; i++)
+    {
+        <div class="map-cell">
+            <MapLibre Options="_mapOptions" Class="rounded-top" Height="400px"/>
+        </div>
+    }
+</div>
+
+@code {
+    private int _mapCount = 1;
+
+    [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
+    private IJSObjectReference _jsModule = null!;
+
+    private readonly MapOptions _mapOptions = new()
+    {
+        Style = "https://demotiles.maplibre.org/style.json"
+    };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _jsModule = await JsRuntime.InvokeAsync<IJSObjectReference>("import",
+                "./_content/Community.Blazor.MapLibre/MapLibre.razor.js");
+        }
+    }
+
+    private void IncreaseMapCount()
+    {
+        _mapCount++;
+        StateHasChanged();
+    }
+
+    private void DecreaseMapCount()
+    {
+        if (_mapCount <= 0) return;
+        _mapCount--;
+        StateHasChanged();
+    }
+
+    private void OnMapCountChange(ChangeEventArgs e)
+    {
+        if (!int.TryParse(e.Value?.ToString(), out var value) || value <= 0) return;
+        _mapCount = value;
+        StateHasChanged();
+    }
+
+    public async ValueTask DisposeAsync() => await _jsModule.DisposeAsync();
+
+}

--- a/examples/Community.Blazor.MapLibre.Examples/Pages/Examples/MultipleMaps.razor.css
+++ b/examples/Community.Blazor.MapLibre.Examples/Pages/Examples/MultipleMaps.razor.css
@@ -1,0 +1,12 @@
+.map-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 1rem;
+}
+
+.map-cell {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    background: #fff;
+    padding: 0.5rem;
+}

--- a/src/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -175,6 +175,7 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
         try
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            await Remove();
             if (_jsModule is not null)
             {
                 await _jsModule.DisposeAsync();

--- a/src/Community.Blazor.MapLibre/MapLibre.razor.js
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor.js
@@ -865,8 +865,16 @@ export function redraw(container) {
  * @param {string} container - The map container.
  */
 export function remove(container) {
-    mapInstances[container].remove();
-    delete mapInstances[container];
+    if (mapInstances[container]) {
+        mapInstances[container].remove();
+        delete mapInstances[container];
+    }
+    if (optionsInstances[container]) {
+        delete optionsInstances[container];
+    }
+    if (markerInstances[container]) {
+        delete markerInstances[container];
+    }
 }
 
 /**


### PR DESCRIPTION
Partially addresses https://github.com/Yet-another-solution/Blazor.MapLibre/issues/123

This PR simply:

- Extends the `.remove()` function of the JavaScript module to delete map option/marker references.
- Invokes the `.Remove()` map component method to call upon the above JavaScript module function.
- Adds an example page showing multiple maps can be added to a single page up until the browsers WebGL context limit.

The end result is that when map components are disposed, the associated map object references are deleted correctly, allow the reserved WebGL contexts to be cleaned up too.

> [!IMPORTANT]
> This pull request does not introduce any ways to recover maps that may have been "corrupted" due to its WebGL context being lost (in the case where too many maps are added to the page). The number of WebGL contexts the browser can maintain is a hard limit it appears and while I think there might be ways to help a map recover from loosing its WebGL context either automatically or manually through some user experience tweaks; those changes are out of scope for this PR and could be evaluated at a future date.

#### References

- [MapLibre already takes care of remove WebGL contexts](https://github.com/maplibre/maplibre-gl-js/blob/93da1d36f23d0d95fcc42f696b5afbd4198c8734/src/ui/map.ts#L3423-L3458); We just needed to invoke it on map component disposal (this PR).
- [You can't destroy a webgl context, they are garbage collected](https://github.com/pixijs/pixijs/issues/2233); We can help with garbage collection by using the `.remove()` MapLibre API correctly (this PR).
-  There is no shortage of complaints about this warning and side effects of contexts being recycled: See [Too many active WebGL contexts. Oldest context will be lost.](https://www.google.com/search?q=Too+many+active+WebGL+contexts.+Oldest+context+will+be+lost.&oq=Too+many+active+WebGL+contexts.+Oldest+context+will+be+lost.)