### PR TITLE
Add .NET 8.0 multi-targeting support

### DIFF
--- a/src/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
+++ b/src/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -28,6 +28,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10"/>
         <PackageReference Include="OneOf" Version="3.0.271" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="System.Text.Json" Version="9.0.7"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Adds support for .NET 8.0 alongside existing .NET 9.0 support.

**Changes:**
- Added `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>` to `Community.Blazor.MapLibre.csproj`
- Upgraded System.Text.Json to 9.0.7 for .NET 8.0 to support `JsonStringEnumMemberName` attribute ([for changing enum member names during JSON serialization](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/customize-properties#custom-enum-member-names))

This allows the library to be used in .NET 8.0 LTS projects while maintaining .NET 9.0 compatibility.
