### PR TITLE
Add capability for async callbacks to be registered for map events

### DIFF
--- a/examples/Community.Blazor.MapLibre.Examples/Pages/Examples/CreatePopup.razor.cs
+++ b/examples/Community.Blazor.MapLibre.Examples/Pages/Examples/CreatePopup.razor.cs
@@ -17,9 +17,9 @@ public partial class CreatePopup
             return;
         }
 
-        await _map.OnClick(null, e => AddPopup(e));
+        await _map.OnClick(null, AddPopup);
 
-        async void AddPopup(MapMouseEvent evnt)
+        async Task AddPopup(MapMouseEvent evnt)
         {
             await _map.CreatePopup(new Popup
             {


### PR DESCRIPTION
This pull request enhances event handling in the MapLibre Blazor component by introducing support for both synchronous and asynchronous event listeners. The changes improve flexibility in how events like map clicks are handled, making it easier to work with async code patterns in Blazor applications.

**Event handling improvements:**

* Added `AddAsyncListener<T>` and refactored the internal event registration to support both synchronous (`Action<T>`) and asynchronous (`Func<T, Task>`) handlers, enabling easier asynchronous event processing. 
* Updated the `OnClick` method to provide overloads for both synchronous and asynchronous click event listeners, allowing developers to choose the appropriate handler type for their use case. 

**Example usage update:**

* Modified the `CreatePopup.razor.cs` example to use an asynchronous handler for map click events, demonstrating the new async event listener capability. 