### PR TITLE
Help with coding task

### DIFF
--- a/src/Community.Blazor.MapLibre/Models/Layers/CircleLayer.cs
+++ b/src/Community.Blazor.MapLibre/Models/Layers/CircleLayer.cs
@@ -20,6 +20,16 @@ public class CircleLayer : Layer<CircleLayerLayout, CircleLayerPaint>
     [JsonPropertyName("source")]
     public required string Source { get; set; }
 
+    /// <summary>
+    /// Gets or sets the layer to use from a vector tile source.
+    /// </summary>
+    /// <remarks>
+    /// Required for vector tile sources. Specifies the layer within the vector tiles to use for this layer.
+    /// </remarks>
+    [JsonPropertyName("source-layer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLayer { get; set; }
+
     [JsonPropertyName("circle-sort-key")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public double? CircleSortKey { get; set; }

--- a/src/Community.Blazor.MapLibre/Models/Layers/FillExtrusionLayer.cs
+++ b/src/Community.Blazor.MapLibre/Models/Layers/FillExtrusionLayer.cs
@@ -16,6 +16,16 @@ public class FillExtrusionLayer : Layer<FillExtrusionLayerLayout, FillExtrusionL
     /// </summary>
     [JsonPropertyName("source")]
     public required string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layer to use from a vector tile source.
+    /// </summary>
+    /// <remarks>
+    /// Required for vector tile sources. Specifies the layer within the vector tiles to use for this layer.
+    /// </remarks>
+    [JsonPropertyName("source-layer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLayer { get; set; }
 }
 
 public class FillExtrusionLayerLayout;

--- a/src/Community.Blazor.MapLibre/Models/Layers/FillLayer.cs
+++ b/src/Community.Blazor.MapLibre/Models/Layers/FillLayer.cs
@@ -19,6 +19,16 @@ public class FillLayer : Layer<FillLayerLayout, FillLayerPaint>
     /// </summary>
     [JsonPropertyName("source")]
     public required string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layer to use from a vector tile source.
+    /// </summary>
+    /// <remarks>
+    /// Required for vector tile sources. Specifies the layer within the vector tiles to use for this layer.
+    /// </remarks>
+    [JsonPropertyName("source-layer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLayer { get; set; }
 }
 
 public class FillLayerLayout

--- a/src/Community.Blazor.MapLibre/Models/Layers/HeatMapLayer.cs
+++ b/src/Community.Blazor.MapLibre/Models/Layers/HeatMapLayer.cs
@@ -16,6 +16,16 @@ public class HeatMapLayer : Layer<HeatMapLayerLayout, HeatMapLayerPaint>
     /// </summary>
     [JsonPropertyName("source")]
     public required string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layer to use from a vector tile source.
+    /// </summary>
+    /// <remarks>
+    /// Required for vector tile sources. Specifies the layer within the vector tiles to use for this layer.
+    /// </remarks>
+    [JsonPropertyName("source-layer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLayer { get; set; }
 }
 
 public class HeatMapLayerLayout;

--- a/src/Community.Blazor.MapLibre/Models/Layers/LineLayer.cs
+++ b/src/Community.Blazor.MapLibre/Models/Layers/LineLayer.cs
@@ -19,6 +19,16 @@ public class LineLayer : Layer<LineLayerLayout, LineLayerPaint>
     /// </summary>
     [JsonPropertyName("source")]
     public required string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layer to use from a vector tile source.
+    /// </summary>
+    /// <remarks>
+    /// Required for vector tile sources. Specifies the layer within the vector tiles to use for this layer.
+    /// </remarks>
+    [JsonPropertyName("source-layer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLayer { get; set; }
 }
 
 public class LineLayerLayout

--- a/src/Community.Blazor.MapLibre/Models/Layers/SymbolLayer.cs
+++ b/src/Community.Blazor.MapLibre/Models/Layers/SymbolLayer.cs
@@ -19,6 +19,16 @@ public class SymbolLayer : Layer<SymbolLayerLayout, SymbolLayerPaint>
     /// </summary>
     [JsonPropertyName("source")]
     public required string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layer to use from a vector tile source.
+    /// </summary>
+    /// <remarks>
+    /// Required for vector tile sources. Specifies the layer within the vector tiles to use for this layer.
+    /// </remarks>
+    [JsonPropertyName("source-layer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLayer { get; set; }
 }
 
 public class SymbolLayerLayout


### PR DESCRIPTION
Added the SourceLayer property to all vector-based layer classes (FillLayer, LineLayer, SymbolLayer, CircleLayer, FillExtrusionLayer, and HeatMapLayer). This property is required when using vector tile sources and specifies which layer within the vector tiles to use for rendering.

The property follows the same pattern as other optional properties with JsonPropertyName("source-layer") and JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull) attributes.

Background, Raster, and Hillshade layers were intentionally excluded as they do not support the source-layer property according to MapLibre GL specification.

Resolves #124