### PR TITLE
Fix #157: GeoJsonDataConverter is not applied correctly when s... (#158)

### DIFF
--- a/src/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
+++ b/src/Community.Blazor.MapLibre/Community.Blazor.MapLibre.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
 
         <PackageId>Community.Blazor.MapLibre</PackageId>
-        <Version>1.4.0-pre1</Version>
+        <Version>1.4.0-pre2</Version>
         <Authors>Yet-Another-Solution</Authors>
         <Description>C# Wrapper around a MapLibre GL JS library</Description>
         <LicenseUrl>https://opensource.org/license/unlicense</LicenseUrl>

--- a/src/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -313,12 +313,18 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
 
     public async ValueTask SetSourceData(string id, GeoJsonSource source)
     {
+        // Serialize the entire source to ensure GeoJsonDataConverter is applied,
+        // then extract just the "data" field to pass to JavaScript.
+        // Using SerializeToNode is more efficient than string serialization + parsing.
+        var jsonNode = System.Text.Json.JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+
         if (_bulkTransaction is not null)
         {
-            _bulkTransaction.Add("setSourceData", id, source.Data);
+            _bulkTransaction.Add("setSourceData", id, dataNode);
             return;
         }
-        await _jsModule.InvokeVoidAsync("setSourceData", MapId, id, source.Data);
+        await _jsModule.InvokeVoidAsync("setSourceData", MapId, id, dataNode);
     }
 
     /// <summary>

--- a/src/Community.Blazor.MapLibre/MapLibre.razor.js
+++ b/src/Community.Blazor.MapLibre/MapLibre.razor.js
@@ -1294,6 +1294,9 @@ export async function executeTransaction(container, data) {
             case "addSprite":
                 addSprite(container, d.data[0], d.data[1], d.data[2]);
                 break;
+            case "setSourceData":
+                setSourceData(container, d.data[0], d.data[1]);
+                break;
             case "removeControl":
                 removeControl(container, d.data[0]);
                 break;

--- a/tests/Community.Blazor.MapLibre.Tests/BulkTransactionTests.cs
+++ b/tests/Community.Blazor.MapLibre.Tests/BulkTransactionTests.cs
@@ -1,0 +1,337 @@
+using System.Text.Json;
+using Community.Blazor.MapLibre.Models;
+using Community.Blazor.MapLibre.Models.Feature;
+using Community.Blazor.MapLibre.Models.Sources;
+using FluentAssertions;
+using Xunit;
+
+namespace Community.Blazor.MapLibre.Tests;
+
+/// <summary>
+/// Tests for bulk transaction support, especially for setSourceData operations.
+/// </summary>
+public class BulkTransactionTests
+{
+    [Fact]
+    public void BulkTransaction_Should_Support_SetSourceData()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            }
+        };
+
+        // Simulate what SetSourceData does (using JsonNode - simpler!)
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+
+        // Act
+        transaction.Add("setSourceData", "test-source", dataNode);
+
+        // Assert
+        transaction.Transactions.Should().HaveCount(1);
+        transaction.Transactions[0].Event.Should().Be("setSourceData");
+        transaction.Transactions[0].Data.Should().HaveCount(2);
+        transaction.Transactions[0].Data![0].Should().Be("test-source");
+    }
+
+    [Fact]
+    public void BulkTransaction_Should_Serialize_SetSourceData_Correctly()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "bulk-test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 10.0, 20.0 } },
+                        Properties = new Dictionary<string, object>
+                        {
+                            { "name", "Bulk Transaction Test" }
+                        }
+                    }
+                }
+            }
+        };
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        
+
+        transaction.Add("setSourceData", "source-id", dataNode);
+
+        // Act
+        var transactionJson = JsonSerializer.Serialize(transaction.Transactions);
+
+        // Assert
+        transactionJson.Should().Contain("setSourceData");
+        transactionJson.Should().Contain("source-id");
+        transactionJson.Should().Contain("FeatureCollection");
+        transactionJson.Should().Contain("Bulk Transaction Test");
+    }
+
+    [Fact]
+    public void BulkTransaction_Should_Handle_Multiple_SetSourceData_Operations()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+
+        var source1 = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "feature1",
+                Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+            }
+        };
+
+        var source2 = new GeoJsonSource
+        {
+            Data = "https://example.com/data.geojson"
+        };
+
+        var json1 = JsonSerializer.Serialize(source1);
+        using var jsonDoc1 = JsonDocument.Parse(json1);
+        var dataNode1 = jsonDoc1.RootElement.GetProperty("data").Clone();
+
+        var json2 = JsonSerializer.Serialize(source2);
+        using var jsonDoc2 = JsonDocument.Parse(json2);
+        var dataNode2 = jsonDoc2.RootElement.GetProperty("data").Clone();
+
+        // Act
+        transaction.Add("setSourceData", "source1", dataNode1);
+        transaction.Add("setSourceData", "source2", dataNode2);
+
+        // Assert
+        transaction.Transactions.Should().HaveCount(2);
+        transaction.Transactions[0].Event.Should().Be("setSourceData");
+        transaction.Transactions[1].Event.Should().Be("setSourceData");
+    }
+
+    [Fact]
+    public void BulkTransaction_Should_Mix_SetSourceData_With_Other_Operations()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            }
+        };
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        
+
+        // Act - Mix different transaction types
+        transaction.Add("addSource", "test-source", source);
+        transaction.Add("setSourceData", "test-source", dataNode);
+        transaction.Add("removeSource", "old-source");
+
+        // Assert
+        transaction.Transactions.Should().HaveCount(3);
+        transaction.Transactions[0].Event.Should().Be("addSource");
+        transaction.Transactions[1].Event.Should().Be("setSourceData");
+        transaction.Transactions[2].Event.Should().Be("removeSource");
+    }
+
+    [Fact]
+    public void BulkTransaction_SetSourceData_Should_Preserve_Complex_GeoJSON()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "complex1",
+                        Geometry = new PolygonGeometry
+                        {
+                            Coordinates = new[]
+                            {
+                                new[]
+                                {
+                                    new[] { 0.0, 0.0 },
+                                    new[] { 10.0, 0.0 },
+                                    new[] { 10.0, 10.0 },
+                                    new[] { 0.0, 10.0 },
+                                    new[] { 0.0, 0.0 }
+                                }
+                            }
+                        },
+                        Properties = new Dictionary<string, object>
+                        {
+                            { "area", "test-area" },
+                            { "size", 100 },
+                            { "tags", new[] { "tag1", "tag2" } }
+                        }
+                    }
+                }
+            }
+        };
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        
+
+        transaction.Add("setSourceData", "complex-source", dataNode);
+
+        // Act
+        var transactionJson = JsonSerializer.Serialize(transaction.Transactions);
+
+        // Assert
+        transactionJson.Should().Contain("Polygon");
+        transactionJson.Should().Contain("test-area");
+        transactionJson.Should().Contain("tag1");
+        transactionJson.Should().Contain("tag2");
+    }
+
+    [Fact]
+    public void BulkTransaction_Should_Handle_Empty_FeatureCollection()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>()
+            }
+        };
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        
+
+        // Act
+        transaction.Add("setSourceData", "empty-source", dataNode);
+        var transactionJson = JsonSerializer.Serialize(transaction.Transactions);
+
+        // Assert
+        transactionJson.Should().Contain("FeatureCollection");
+        transactionJson.Should().Contain("\"features\":[]");
+    }
+
+    [Fact]
+    public void BulkTransaction_With_URL_String_Should_Serialize()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+        var source = new GeoJsonSource
+        {
+            Data = "https://api.example.com/features.geojson"
+        };
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        
+
+        // Act
+        transaction.Add("setSourceData", "url-source", dataNode);
+        var transactionJson = JsonSerializer.Serialize(transaction.Transactions);
+
+        // Assert
+        transactionJson.Should().Contain("https://api.example.com/features.geojson");
+    }
+
+    [Fact]
+    public void BulkTransaction_Serialization_Should_Be_Efficient()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+
+        for (int i = 0; i < 50; i++)
+        {
+            var source = new GeoJsonSource
+            {
+                Data = new FeatureFeature
+                {
+                    Id = $"feature-{i}",
+                    Geometry = new PointGeometry { Coordinates = new[] { (double)i, (double)i } },
+                    Properties = new Dictionary<string, object>
+                    {
+                        { "index", i }
+                    }
+                }
+            };
+
+            var jsonNode = JsonSerializer.SerializeToNode(source);
+            var dataNode = jsonNode!["data"];
+            
+
+            transaction.Add("setSourceData", $"source-{i}", dataNode);
+        }
+
+        // Act
+        var startTime = DateTime.UtcNow;
+        var transactionJson = JsonSerializer.Serialize(transaction.Transactions);
+        var duration = DateTime.UtcNow - startTime;
+
+        // Assert
+        duration.Should().BeLessThan(TimeSpan.FromSeconds(1),
+            "bulk transaction serialization should be fast");
+        transaction.Transactions.Should().HaveCount(50);
+    }
+
+    [Fact]
+    public void BulkTransaction_Should_Maintain_Order_Of_Operations()
+    {
+        // Arrange
+        var transaction = new BulkTransaction();
+
+        var source1 = new GeoJsonSource { Data = "https://example.com/1.json" };
+        var source2 = new GeoJsonSource { Data = "https://example.com/2.json" };
+        var source3 = new GeoJsonSource { Data = "https://example.com/3.json" };
+
+        var json1 = JsonSerializer.Serialize(source1);
+        using var jsonDoc1 = JsonDocument.Parse(json1);
+        var data1 = jsonDoc1.RootElement.GetProperty("data").Clone();
+
+        var json2 = JsonSerializer.Serialize(source2);
+        using var jsonDoc2 = JsonDocument.Parse(json2);
+        var data2 = jsonDoc2.RootElement.GetProperty("data").Clone();
+
+        var json3 = JsonSerializer.Serialize(source3);
+        using var jsonDoc3 = JsonDocument.Parse(json3);
+        var data3 = jsonDoc3.RootElement.GetProperty("data").Clone();
+
+        // Act
+        transaction.Add("setSourceData", "source-A", data1);
+        transaction.Add("setSourceData", "source-B", data2);
+        transaction.Add("setSourceData", "source-C", data3);
+
+        // Assert
+        transaction.Transactions[0].Data![0].Should().Be("source-A");
+        transaction.Transactions[1].Data![0].Should().Be("source-B");
+        transaction.Transactions[2].Data![0].Should().Be("source-C");
+    }
+}

--- a/tests/Community.Blazor.MapLibre.Tests/SerializationApproachTests.cs
+++ b/tests/Community.Blazor.MapLibre.Tests/SerializationApproachTests.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Community.Blazor.MapLibre.Models.Feature;
+using Community.Blazor.MapLibre.Models.Sources;
+using FluentAssertions;
+using Xunit;
+
+namespace Community.Blazor.MapLibre.Tests;
+
+/// <summary>
+/// Tests to compare different serialization approaches and verify the simplest working solution.
+/// </summary>
+public class SerializationApproachTests
+{
+    [Fact]
+    public void Approach1_StringParse_Works()
+    {
+        // Arrange - Current implementation approach
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            }
+        };
+
+        // Act - Serialize -> Parse -> Extract
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+        var resultJson = JsonSerializer.Serialize(dataElement);
+
+        // Assert
+        resultJson.Should().Contain("FeatureCollection");
+        resultJson.Should().NotContain("geojson");
+    }
+
+    [Fact]
+    public void Approach2_JsonNode_Works()
+    {
+        // Arrange - Alternative using JsonNode
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            }
+        };
+
+        // Act - Serialize to JsonNode and extract
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        var resultJson = JsonSerializer.Serialize(dataNode);
+
+        // Assert
+        resultJson.Should().Contain("FeatureCollection");
+        resultJson.Should().NotContain("geojson");
+    }
+
+    [Fact]
+    public void Approach3_DirectSerialization_Fails()
+    {
+        // Arrange - What happens if we try to serialize source.Data directly?
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            }
+        };
+
+        // Act - Try to serialize the Data property directly
+        // This SHOULD work because Data is IFeature which has proper polymorphic attributes
+        var json = JsonSerializer.Serialize(source.Data.AsT0);
+
+        // Assert
+        json.Should().Contain("FeatureCollection");
+    }
+
+    [Fact]
+    public void Approach_Comparison_URL_String()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = "https://example.com/data.geojson"
+        };
+
+        // Act - Test both approaches with URL string
+        // Approach 1: String -> Parse -> Extract
+        var json1 = JsonSerializer.Serialize(source);
+        using var jsonDoc1 = JsonDocument.Parse(json1);
+        var data1 = jsonDoc1.RootElement.GetProperty("data");
+
+        // Approach 2: JsonNode
+        var jsonNode2 = JsonSerializer.SerializeToNode(source);
+        var data2 = jsonNode2!["data"];
+
+        // Assert - Both should produce same result
+        data1.GetString().Should().Be("https://example.com/data.geojson");
+        data2!.GetValue<string>().Should().Be("https://example.com/data.geojson");
+    }
+
+    [Fact]
+    public void JsonNode_Can_Be_Passed_To_JSInterop()
+    {
+        // Arrange - Verify JsonNode serializes correctly for JS interop
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "interop-test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 10.0, 20.0 } }
+                    }
+                }
+            }
+        };
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+
+        // Act - Simulate what JS interop would do
+        var serializedForInterop = JsonSerializer.Serialize(dataNode);
+
+        // Assert
+        serializedForInterop.Should().Contain("FeatureCollection");
+        serializedForInterop.Should().Contain("interop-test");
+    }
+
+    [Fact]
+    public void JsonElement_Vs_JsonNode_Comparison()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "compare",
+                Geometry = new PointGeometry { Coordinates = new[] { 1.0, 2.0 } },
+                Properties = new Dictionary<string, object>
+                {
+                    { "name", "Test" }
+                }
+            }
+        };
+
+        // Act - Compare JsonElement vs JsonNode output
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var jsonElement = jsonDoc.RootElement.GetProperty("data");
+        var elementResult = JsonSerializer.Serialize(jsonElement);
+
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+        var nodeResult = JsonSerializer.Serialize(dataNode);
+
+        // Assert - Both should produce identical JSON
+        elementResult.Should().Be(nodeResult);
+    }
+}

--- a/tests/Community.Blazor.MapLibre.Tests/SetSourceDataTests.cs
+++ b/tests/Community.Blazor.MapLibre.Tests/SetSourceDataTests.cs
@@ -1,0 +1,486 @@
+using System.Text.Json;
+using Community.Blazor.MapLibre.Models.Feature;
+using Community.Blazor.MapLibre.Models.Sources;
+using FluentAssertions;
+using Xunit;
+
+namespace Community.Blazor.MapLibre.Tests;
+
+/// <summary>
+/// Comprehensive tests for the SetSourceData method to ensure proper serialization
+/// of GeoJSON data with the GeoJsonDataConverter applied correctly.
+/// </summary>
+public class SetSourceDataTests
+{
+    [Fact]
+    public void GeoJsonSource_Serialization_Should_Apply_Converter_To_FeatureCollection()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "point1",
+                        Geometry = new PointGeometry
+                        {
+                            Coordinates = new[] { -122.4194, 37.7749 }
+                        },
+                        Properties = new Dictionary<string, object>
+                        {
+                            { "name", "San Francisco" }
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.ValueKind.Should().Be(JsonValueKind.Object);
+        dataElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        dataElement.GetProperty("features").ValueKind.Should().Be(JsonValueKind.Array);
+        dataElement.GetProperty("features").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
+    public void GeoJsonSource_Serialization_Should_Apply_Converter_To_Single_Feature()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "single-point",
+                Geometry = new PointGeometry
+                {
+                    Coordinates = new[] { 10.0, 20.0 }
+                },
+                Properties = new Dictionary<string, object>
+                {
+                    { "category", "landmark" }
+                }
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.ValueKind.Should().Be(JsonValueKind.Object);
+        dataElement.GetProperty("type").GetString().Should().Be("Feature");
+        dataElement.GetProperty("id").GetString().Should().Be("single-point");
+        dataElement.GetProperty("geometry").GetProperty("type").GetString().Should().Be("Point");
+    }
+
+    [Fact]
+    public void GeoJsonSource_Serialization_Should_Apply_Converter_To_URL_String()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = "https://api.example.com/geojson/data.json"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.ValueKind.Should().Be(JsonValueKind.String);
+        dataElement.GetString().Should().Be("https://api.example.com/geojson/data.json");
+    }
+
+    [Fact]
+    public void Extracted_Data_Should_Not_Contain_Source_Type()
+    {
+        // Arrange - The extracted data should only contain GeoJSON, not the source wrapper
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            },
+            Cluster = true,
+            ClusterRadius = 50
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+        var dataJson = dataElement.ToString();
+
+        // Assert
+        dataJson.Should().NotContain("geojson", "data field should not contain source type");
+        dataJson.Should().NotContain("cluster", "data field should not contain source properties");
+        dataJson.Should().Contain("FeatureCollection");
+    }
+
+    [Fact]
+    public void Complex_FeatureCollection_Should_Serialize_All_Geometry_Types()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "point",
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    },
+                    new FeatureFeature
+                    {
+                        Id = "line",
+                        Geometry = new LineGeometry
+                        {
+                            Coordinates = new[] { new[] { 0.0, 0.0 }, new[] { 1.0, 1.0 } }
+                        }
+                    },
+                    new FeatureFeature
+                    {
+                        Id = "polygon",
+                        Geometry = new PolygonGeometry
+                        {
+                            Coordinates = new[]
+                            {
+                                new[]
+                                {
+                                    new[] { 0.0, 0.0 },
+                                    new[] { 1.0, 0.0 },
+                                    new[] { 1.0, 1.0 },
+                                    new[] { 0.0, 1.0 },
+                                    new[] { 0.0, 0.0 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+        var dataJson = dataElement.ToString();
+
+        // Assert
+        dataJson.Should().Contain("Point");
+        dataJson.Should().Contain("LineString");
+        dataJson.Should().Contain("Polygon");
+
+        var features = dataElement.GetProperty("features");
+        features.GetArrayLength().Should().Be(3);
+    }
+
+    [Fact]
+    public void Empty_FeatureCollection_Should_Serialize_Correctly()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>()
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        dataElement.GetProperty("features").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public void Feature_With_Null_Properties_Should_Serialize()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "no-props",
+                Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } },
+                Properties = null
+            }
+        };
+
+        // Act
+        Action act = () =>
+        {
+            var json = JsonSerializer.Serialize(source);
+            using var jsonDoc = JsonDocument.Parse(json);
+            var dataElement = jsonDoc.RootElement.GetProperty("data");
+        };
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Feature_With_Complex_Properties_Should_Serialize()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "complex",
+                Geometry = new PointGeometry { Coordinates = new[] { -122.4194, 37.7749 } },
+                Properties = new Dictionary<string, object>
+                {
+                    { "name", "Complex Feature" },
+                    { "count", 42 },
+                    { "active", true },
+                    { "rating", 4.5 },
+                    { "tags", new[] { "tag1", "tag2", "tag3" } },
+                    { "metadata", new Dictionary<string, object>
+                        {
+                            { "created", "2024-01-01" },
+                            { "updated", "2024-01-15" }
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+        var dataJson = dataElement.ToString();
+
+        // Assert
+        dataJson.Should().Contain("Complex Feature");
+        dataJson.Should().Contain("42");
+        dataJson.Should().Contain("true");
+        dataJson.Should().Contain("4.5");
+        dataJson.Should().Contain("tag1");
+        dataJson.Should().Contain("metadata");
+    }
+
+    [Fact]
+    public void Large_FeatureCollection_Should_Extract_Data_Efficiently()
+    {
+        // Arrange
+        var features = Enumerable.Range(0, 1000).Select(i => new FeatureFeature
+        {
+            Id = $"feature-{i}",
+            Geometry = new PointGeometry
+            {
+                Coordinates = new[] { -180.0 + i * 0.36, -90.0 + i * 0.18 }
+            },
+            Properties = new Dictionary<string, object>
+            {
+                { "index", i },
+                { "name", $"Feature {i}" }
+            }
+        }).Cast<IFeature>().ToList();
+
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection { Features = features }
+        };
+
+        // Act
+        var startTime = DateTime.UtcNow;
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+        var duration = DateTime.UtcNow - startTime;
+
+        // Assert
+        duration.Should().BeLessThan(TimeSpan.FromSeconds(2),
+            "extracting data from large collection should be fast");
+        dataElement.GetProperty("features").GetArrayLength().Should().Be(1000);
+    }
+
+    [Fact]
+    public void MultiPolygon_Geometry_Should_Serialize_Correctly()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "multi-poly",
+                Geometry = new MultiPolygonGeometry
+                {
+                    Coordinates = new[]
+                    {
+                        new[]
+                        {
+                            new[]
+                            {
+                                new[] { 0.0, 0.0 },
+                                new[] { 1.0, 0.0 },
+                                new[] { 1.0, 1.0 },
+                                new[] { 0.0, 1.0 },
+                                new[] { 0.0, 0.0 }
+                            }
+                        },
+                        new[]
+                        {
+                            new[]
+                            {
+                                new[] { 2.0, 2.0 },
+                                new[] { 3.0, 2.0 },
+                                new[] { 3.0, 3.0 },
+                                new[] { 2.0, 3.0 },
+                                new[] { 2.0, 2.0 }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.GetProperty("geometry").GetProperty("type").GetString()
+            .Should().Be("MultiPolygon");
+        dataElement.GetProperty("geometry").GetProperty("coordinates").GetArrayLength()
+            .Should().Be(2);
+    }
+
+    [Fact]
+    public void GeoJsonSource_With_All_Optional_Properties_Should_Not_Affect_Data_Extraction()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+                    }
+                }
+            },
+            Cluster = true,
+            ClusterMaxZoom = 14,
+            ClusterRadius = 50,
+            ClusterMinPoints = 2,
+            GenerateId = true,
+            Buffer = 128,
+            Tolerance = 0.375f,
+            LineMetrics = true,
+            MinZoom = 0,
+            MaxZoom = 22,
+            TileSize = 512,
+            Attribution = "© Test Attribution"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert - The data element should only contain the GeoJSON data
+        dataElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        dataElement.TryGetProperty("cluster", out _).Should().BeFalse(
+            "data should not contain source configuration");
+        dataElement.TryGetProperty("buffer", out _).Should().BeFalse(
+            "data should not contain source configuration");
+    }
+
+    [Fact]
+    public void JsonNode_Should_Work_For_Bulk_Transactions()
+    {
+        // Arrange - Test that JsonNode works for bulk transactions (no Clone needed)
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureCollection
+            {
+                Features = new List<IFeature>
+                {
+                    new FeatureFeature
+                    {
+                        Id = "node-test",
+                        Geometry = new PointGeometry { Coordinates = new[] { 1.0, 2.0 } }
+                    }
+                }
+            }
+        };
+
+        // Act - Using JsonNode (simpler approach)
+        var jsonNode = JsonSerializer.SerializeToNode(source);
+        var dataNode = jsonNode!["data"];
+
+        // Assert - Node should serialize correctly
+        var nodeJson = JsonSerializer.Serialize(dataNode);
+        nodeJson.Should().Contain("FeatureCollection");
+        nodeJson.Should().Contain("node-test");
+    }
+
+    [Fact]
+    public void Relative_URL_String_Should_Serialize_Correctly()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = "/api/geojson/features"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.ValueKind.Should().Be(JsonValueKind.String);
+        dataElement.GetString().Should().Be("/api/geojson/features");
+    }
+
+    [Fact]
+    public void Feature_With_Numeric_String_Id_Should_Serialize()
+    {
+        // Arrange
+        var source = new GeoJsonSource
+        {
+            Data = new FeatureFeature
+            {
+                Id = "12345",
+                Geometry = new PointGeometry { Coordinates = new[] { 0.0, 0.0 } }
+            }
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(source);
+        using var jsonDoc = JsonDocument.Parse(json);
+        var dataElement = jsonDoc.RootElement.GetProperty("data");
+
+        // Assert
+        dataElement.GetProperty("id").GetString().Should().Be("12345");
+    }
+}


### PR DESCRIPTION
* fix: apply GeoJsonDataConverter when calling SetSourceData

The SetSourceData method was failing with serialization errors because the GeoJsonDataConverter was not being applied when passing source.Data directly to JS interop. The converter attribute is on the property in GeoJsonSource, so it was only applied when serializing the entire object.

This fix:
- Serializes the entire GeoJsonSource to ensure the converter is applied
- Extracts just the "data" field from the serialized JSON
- Passes the properly serialized data to JavaScript

Also added support for setSourceData in bulk transactions and comprehensive tests to verify the fix works for both FeatureCollection and URL string data.

Fixes #157

* test: add comprehensive tests for SetSourceData fix

Added two new test suites to ensure the SetSourceData fix works correctly:

1. SetSourceDataTests.cs:
   - Tests GeoJsonSource serialization with FeatureCollection
   - Tests single Feature serialization
   - Tests URL string data
   - Tests complex properties and geometry types
   - Tests data extraction doesn't include source configuration
   - Tests JsonElement.Clone() for bulk transactions
   - Tests edge cases like empty collections and null properties
   - Performance tests for large datasets

2. BulkTransactionTests.cs:
   - Tests setSourceData support in bulk transactions
   - Tests multiple setSourceData operations in one transaction
   - Tests mixing setSourceData with other operations
   - Tests complex GeoJSON preservation in transactions
   - Tests URL strings in bulk transactions
   - Tests operation ordering
   - Performance tests for bulk operations

These tests verify that the GeoJsonDataConverter is properly applied and that the extracted data maintains the correct GeoJSON structure without including source configuration properties.

* refactor: simplify SetSourceData using JsonNode instead of JsonDocument

Improved the SetSourceData implementation to be simpler and more efficient:

BEFORE (JsonDocument approach - 4 lines):
- Serialize to string
- Parse string to JsonDocument
- Extract property with Clone()
- Requires 'using' statement

AFTER (JsonNode approach - 2 lines):
- Serialize directly to JsonNode
- Extract property with indexer
- No Clone() needed
- No 'using' statement

Benefits:
✅ Simpler code (4 lines → 2 lines)
✅ More efficient (no string allocation/parsing)
✅ More intuitive syntax (["data"] vs GetProperty)
✅ No manual disposal needed
✅ Same functionality and test coverage

Also added:
- Comprehensive documentation explaining the fix and why it works
- SerializationApproachTests comparing both approaches
- Updated all tests to use the simpler JsonNode pattern

The fix still works the same way: serialize the full GeoJsonSource to ensure the converter is applied, then extract just the "data" field.

* docs: add visual explanation of SetSourceData fix

* fix(interop): ensure correct serialization of GeoJsonSource data

- Refactored `SetSourceData` to use `JsonSerializer.SerializeToNode` for extracting the correctly-converted `data` field, replacing the less efficient `JsonDocument` approach.
- Simplifies code, improves performance, and ensures compatibility with JS interop by providing properly serialized GeoJSON data without additional source configuration.

* chore(release): bump version to 1.4.0-pre2

- Updated the project version in `Community.Blazor.MapLibre.csproj` from 1.4.0-pre1 to 1.4.0-pre2. This version bump reflects preparation for a new pre-release, ensuring alignment with semantic versioning and readiness for further development or testing.

---------